### PR TITLE
Removal of master-slave language

### DIFF
--- a/main/migrations/0002_auto_20170728_2304.py
+++ b/main/migrations/0002_auto_20170728_2304.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name='Modbus',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('role', models.CharField(choices=[('master', 'master'), ('slave', 'slave')], default='slave', max_length=10, verbose_name='Роль устройства')),
+                ('role', models.CharField(choices=[('main', 'main'), ('subordinate', 'subordinate')], default='subordinate', max_length=10, verbose_name='Роль устройства')),
                 ('data_type', models.CharField(choices=[('coils', 'Coils'), ('discrete_inputs', 'Discrete Inputs'), ('input_registers', 'Input Registers'), ('holding_registers', 'Holding Registers')], default='Coils', max_length=20, verbose_name='Тип данных')),
             ],
             options={

--- a/main/migrations/0005_auto_20170729_0910.py
+++ b/main/migrations/0005_auto_20170729_0910.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('device_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='main.Device')),
                 ('mqtt_type', models.CharField(choices=[('mqtt', 'MQTT'), ('mqtt-sn', 'MQTT-SN')], default='mqtt', max_length=10, verbose_name='Видпротокола')),
-                ('role', models.CharField(choices=[('publisher', 'Publisher'), ('consumer', 'Consumer')], default='slave', max_length=10, verbose_name='Роль устройства')),
+                ('role', models.CharField(choices=[('publisher', 'Publisher'), ('consumer', 'Consumer')], default='subordinate', max_length=10, verbose_name='Роль устройства')),
             ],
             options={
                 'verbose_name': 'Устройство MQTT',

--- a/main/models.py
+++ b/main/models.py
@@ -14,8 +14,8 @@ class Device(models.Model):
 
 class ModbusDevice(Device):
     role_choices = (
-        ('master', 'master'),
-        ('slave', 'slave'),
+        ('main', 'main'),
+        ('subordinate', 'subordinate'),
     )
     data_type_choices = (
         ('coils', 'Coils'),
@@ -29,7 +29,7 @@ class ModbusDevice(Device):
         ('rtu', 'RTU'),
     )
     modbus_type = models.CharField("Вид протокола", max_length=10, choices=modbus_type_choices, default='tcp')
-    role = models.CharField("Роль устройства", max_length=10, choices=role_choices, default='slave')
+    role = models.CharField("Роль устройства", max_length=10, choices=role_choices, default='subordinate')
     data_type = models.CharField("Тип данных", max_length=20, choices=data_type_choices, default='coils')
     
     class Meta:
@@ -50,7 +50,7 @@ class MQTTDevice(Device):
         ('consumer', 'Consumer'),
     )
     mqtt_type = models.CharField("Видпротокола",max_length=10, choices=mqtt_type_choices, default='mqtt')
-    role = models.CharField("Роль устройства", max_length=10, choices=role_choices, default='slave')
+    role = models.CharField("Роль устройства", max_length=10, choices=role_choices, default='subordinate')
 
     class Meta:
         verbose_name = "Устройство MQTT"


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.